### PR TITLE
1910 test

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -13,6 +13,7 @@
 
     # Software Settings
     - include: tasks/software/repos.yml
+      # Tmp removed until the repo supports 19.10
       #- include: tasks/software/docker.yml
     - include: tasks/software/apt.yml
     - include: tasks/software/snap.yml
@@ -25,8 +26,8 @@
     - include: tasks/system/services.yml
     - include: tasks/system/timezone.yml
     - include: tasks/system/ufw.yml
-      #- include: tasks/system/dns.yml
 
+      #- include: tasks/system/dns.yml
     # User Settings
     - include: tasks/user/groups.yml
     - include: tasks/user/users.yml

--- a/local.yml
+++ b/local.yml
@@ -13,7 +13,7 @@
 
     # Software Settings
     - include: tasks/software/repos.yml
-    - include: tasks/software/docker.yml
+      #- include: tasks/software/docker.yml
     - include: tasks/software/apt.yml
     - include: tasks/software/snap.yml
     - include: tasks/software/pip.yml

--- a/tasks/software/apt.yml
+++ b/tasks/software/apt.yml
@@ -69,7 +69,6 @@
       - seafile-cli
       - dialog
       - pdfarranger
-        #   - cryptomator
       - hub
       - rename
       - lazygit

--- a/tasks/software/apt.yml
+++ b/tasks/software/apt.yml
@@ -67,9 +67,6 @@
       - gtk-3-examples
       - libgtk-3-0
       - seafile-cli
-        #      - pop-icon-theme-extra
-        #     - pop-gtk-theme
-        #    - hidpi-daemon
       - dialog
       - pdfarranger
         #   - cryptomator

--- a/tasks/software/apt.yml
+++ b/tasks/software/apt.yml
@@ -66,12 +66,13 @@
       - pylint
       - gtk-3-examples
       - libgtk-3-0
-      - pop-icon-theme-extra
-      - pop-gtk-theme
-      - hidpi-daemon
+      - seafile-cli
+        #      - pop-icon-theme-extra
+        #     - pop-gtk-theme
+        #    - hidpi-daemon
       - dialog
       - pdfarranger
-      - cryptomator
+        #   - cryptomator
       - hub
       - rename
       - lazygit

--- a/tasks/software/repos.yml
+++ b/tasks/software/repos.yml
@@ -5,9 +5,9 @@
     state: present
   with_items:
     - ppa:ubuntubudgie/backports
-    - ppa:seafile/seafile-client
-    - ppa:system76/pop
-    - ppa:sebastian-stenzel/cryptomator
+      #    - ppa:seafile/seafile-client
+      #    - ppa:system76/pop
+      #    - ppa:sebastian-stenzel/cryptomator
     - ppa:lazygit-team/release
 
 - name: Add Canonical Partners PPA

--- a/tasks/software/repos.yml
+++ b/tasks/software/repos.yml
@@ -5,9 +5,6 @@
     state: present
   with_items:
     - ppa:ubuntubudgie/backports
-      #    - ppa:seafile/seafile-client
-      #    - ppa:system76/pop
-      #    - ppa:sebastian-stenzel/cryptomator
     - ppa:lazygit-team/release
 
 - name: Add Canonical Partners PPA

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -17,6 +17,7 @@
     - ffsend
     - pick-colour-picker
     - mailspring
+    - docker
 - name: Install Classic Snap Packages
   command: 'snap install "{{ item }}" --classic'
   with_items:

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -35,12 +35,5 @@
 
 - name: Install IRCCLOUD Desktop Snap Package
   command: "snap install irccloud --edge"
-- name: Remmina Snap CFG
-  command: 'snap connect remmina:"{{ item }}" :"{{ item }}"'
-  with_items:
-    - avahi-observe
-    - cups-control
-    - mount-observe
-    - password-manager-service
 - name: Install Hugo Extended
   command: "snap install hugo --channel=extended/edge"

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -24,7 +24,6 @@
     - restic
     - snapcraft
     - snapdiff
-    - kubectl
     - code-insiders
     - slack
 

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -1,7 +1,6 @@
 - name: Install Snap Packages
   command: 'snap install "{{ item }}"'
   with_items:
-    - irccloud
     - libreoffice
     - spotify
     - lxd
@@ -37,6 +36,12 @@
 
 - name: Install IRCCLOUD Desktop Snap Package
   command: "snap install irccloud --edge"
-
+- name: Remmina Snap CFG
+  command: 'snap connect remmina:"{{ item }}" :"{{ item }}"'
+  with_items:
+    - avahi-observe
+    - cups-control
+    - mount-observe
+    - password-manager-service
 - name: Install Hugo Extended
   command: "snap install hugo --channel=extended/edge"

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -3,7 +3,6 @@
   with_items:
     - irccloud
     - libreoffice
-    - remmina
     - spotify
     - lxd
     - telegram-desktop

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -31,13 +31,6 @@
 
 - name: Install Node Snap Package
   command: "snap install node --channel=11/stable --classic"
-- name: Remmina Snap CFG
-  command: 'snap connect remmina:"{{ item }}" :"{{ item }}"'
-  with_items:
-    - avahi-observe
-    - cups-control
-    - mount-observe
-    - password-manager-service
 
 - name: Install Multipass Snap Package
   command: "snap install multipass --beta --classic"

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -28,7 +28,6 @@
     - kubectl
     - code-insiders
     - slack
-    - snippetpixie
 
 - name: Install Node Snap Package
   command: "snap install node --channel=11/stable --classic"

--- a/tasks/software/snap.yml
+++ b/tasks/software/snap.yml
@@ -1,45 +1,45 @@
 - name: Install Snap Packages
   command: 'snap install "{{ item }}"'
   with_items:
-        - irccloud-desktop
-        - libreoffice
-        - remmina
-        - spotify
-        - lxd
-        - telegram-desktop
-        - simplescreenrecorder
-        - bitwarden
-        - bw
-        - serve
-        - icdiff
-        - mumble
-        - typora-alanzanattadev
-        - youtube-dl
-        - shfmt
-        - ffsend
-        - pick-colour-picker
-        - mailspring
+    - irccloud
+    - libreoffice
+    - remmina
+    - spotify
+    - lxd
+    - telegram-desktop
+    - simplescreenrecorder
+    - bitwarden
+    - bw
+    - serve
+    - icdiff
+    - mumble
+    - typora-alanzanattadev
+    - youtube-dl
+    - shfmt
+    - ffsend
+    - pick-colour-picker
+    - mailspring
 - name: Install Classic Snap Packages
   command: 'snap install "{{ item }}" --classic'
   with_items:
-        - go
-        - restic
-        - snapcraft
-        - snapdiff
-        - kubectl
-        - code-insiders
-        - slack
-        - snippetpixie
+    - go
+    - restic
+    - snapcraft
+    - snapdiff
+    - kubectl
+    - code-insiders
+    - slack
+    - snippetpixie
 
 - name: Install Node Snap Package
   command: "snap install node --channel=11/stable --classic"
 - name: Remmina Snap CFG
   command: 'snap connect remmina:"{{ item }}" :"{{ item }}"'
   with_items:
-        - avahi-observe
-        - cups-control
-        - mount-observe
-        - password-manager-service
+    - avahi-observe
+    - cups-control
+    - mount-observe
+    - password-manager-service
 
 - name: Install Multipass Snap Package
   command: "snap install multipass --beta --classic"

--- a/tasks/user/visual/theme.yml
+++ b/tasks/user/visual/theme.yml
@@ -3,34 +3,34 @@
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/org/gnome/desktop/interface/cursor-theme"
-      value: "'Pop'"
-      state: present
+    key: "/org/gnome/desktop/interface/cursor-theme"
+    value: "'DMZ-Black'"
+    state: present
 
 - name: Set System Theme
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/org/gnome/desktop/interface/gtk-theme"
-      # Needed extra quotes due to unlnown key error
-      value: "'Pop-slim-dark'"
-      state: present
+    key: "/org/gnome/desktop/interface/gtk-theme"
+    # Needed extra quotes due to unlnown key error
+    value: "'QogirBudgie-dark'"
+    state: present
 
 - name: Set Icon Theme
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/org/gnome/desktop/interface/icon-theme"
-      value: "'Pop'"
-      state: present
+    key: "/org/gnome/desktop/interface/icon-theme"
+    value: "'Zafiro'"
+    state: present
 
 - name: Set Theme to Dark
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/com/solus-project/budgie-panel/dark-theme"
-      value: "true"
-      state: present
+    key: "/com/solus-project/budgie-panel/dark-theme"
+    value: "true"
+    state: present
 
 ## Window Controls
 
@@ -40,14 +40,14 @@
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/com/solus-project/budgie-wm/button-layout"
-      value: "'close,minimize,maximize:appmenu'"
-      state: present
+    key: "/com/solus-project/budgie-wm/button-layout"
+    value: "'close,minimize,maximize:appmenu'"
+    state: present
 
 - name: Set Window Controls Button Style
   become: true
   become_user: "{{ myusername }}"
   dconf:
-      key: "/com/solus-project/budgie-wm/button-style"
-      value: "'right'"
-      state: present
+    key: "/com/solus-project/budgie-wm/button-style"
+    value: "'right'"
+    state: present


### PR DESCRIPTION
Tested for 19.10. I no longer run any of the pre 19.10 version. The biggest issue would be the seafile PPA (being removed).

Primary changes:

- Moved to the Canonical Docker snap as it is good enough for a laptop. Docker is not yet available in a PPA for 19.10. I left the docker task in the repo in case I go back to a PPA version later. I plan on seeing how often the snap is updated.
- Removed the Seafile PPA as the seafile-cli package is in the main repo.
- I cleaned up some additional packages I no longer need.
- Updated the themes to go back to one of the standard Ubuntu Budgie themes.
- No longer need to install the POP OS repo to get their 4 k goodies.